### PR TITLE
Fix example managed policy file

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,7 +74,9 @@ file should look something like this:
 ```json
 {
   "KeyPermissions": {
-    "monnheglpedplnifignjahmadpadlmgj": "allowCorporateKeyUsage"
+    "monnheglpedplnifignjahmadpadlmgj": {
+      "allowCorporateKeyUsage": true
+    }
   }
 }
 ```


### PR DESCRIPTION
"KeyPermissions" has always been a 2-layered hash, but it looks like I made a mistake when generating the sample file. The previous format is rejected by Chrome as not matching the expected schema.

r? @carl-stripe

I couldn't find a direct citation for the format of this key, but https://www.chromium.org/administrators/policy-list-3#KeyPermissions refers it indirectly. Also I tested it today on my Chromebook.